### PR TITLE
Make the json files valid by removing the comments

### DIFF
--- a/AU-global_conf.json
+++ b/AU-global_conf.json
@@ -1,17 +1,3 @@
-/*
-*
-*	The Things Network: AU Region Configuration Parameters
-*
-*	Note: This only contains parameters that should not
-*	be overridden by either TTN or regulatory policies.
-*
-*   Sub-band: 2 (of sub-bands numbered 1 to 8)
-*
-*	Change Log:
-*		   2016-04-26 Created (tftelkamp)
-*
-*/
-
 {
 	"SX1301_conf": {
 		"lorawan_public": true,
@@ -210,8 +196,8 @@
 		"serv_port_down": 1700,
 		"servers": [ {
 			"server_address": "router.au.thethings.network",
-			"serv_port_up": 1700, 
-			"serv_port_down": 1700, 
+			"serv_port_up": 1700,
+			"serv_port_down": 1700,
 			"serv_enabled": true
 		} ]
 	}

--- a/EU-global_conf.json
+++ b/EU-global_conf.json
@@ -1,16 +1,3 @@
-/*
-*
-*	The Things Network: EU Region Configuration Parameters
-*
-*	Note: This only contains parameters that should not
-*	be overridden by either TTN or regulatory policies.
-*
-*	Change Log:
-*		   2016-03-22 Created (rayozzie)
-*                  2016-04-15 Server settings for EU (johanstokking)
-*
-*/
-
 {
 	"SX1301_conf": {
 		"lorawan_public": true,
@@ -213,8 +200,8 @@
 		"serv_port_down": 1700,
 		"servers": [ {
 			"server_address": "router.eu.thethings.network",
-			"serv_port_up": 1700, 
-			"serv_port_down": 1700, 
+			"serv_port_up": 1700,
+			"serv_port_down": 1700,
 			"serv_enabled": true
 		} ]
 	}

--- a/US-global_conf.json
+++ b/US-global_conf.json
@@ -1,17 +1,3 @@
-/*
-*
-*	The Things Network: US Region Configuration Parameters
-*
-*	Note: This only contains parameters that should not
-*	be overridden by either TTN or regulatory policies.
-*
-*   Sub-band: 2 (of sub-bands numbered 1 to 8)
-*
-*	Change Log:
-*		   2016-04-25 Created (tftelkamp)
-*
-*/
-
 {
 	"SX1301_conf": {
 		"lorawan_public": true,
@@ -210,8 +196,8 @@
 		"serv_port_down": 1700,
 		"servers": [ {
 			"server_address": "router.us.thethings.network",
-			"serv_port_up": 1700, 
-			"serv_port_down": 1700, 
+			"serv_port_up": 1700,
+			"serv_port_down": 1700,
 			"serv_enabled": true
 		} ]
 	}


### PR DESCRIPTION
The config files were not valid JSON and so could not be used directly. Now they are.
