### PR TITLE
Add file with list of configs for scripted installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Due to the difficulty of updating gateways in the field, we recommend that this 
 Each gateway should be configured with a two-letter "region code" from which the configuration file name can be derived and subsequently loaded using HTTPS. For example, if the configured region is "EU", the gateway will then load and initialize the gateway/s "global_conf.json" file (i.e. using CURL) from: 
 
 https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master/EU-global_conf.json
+
+NOTE: These config files cannot be used with the poly_pkt_fwd for MultiTech Conduits without modifications! The forwarder will not start/run when attempting to use the files as they are.

--- a/configs.txt
+++ b/configs.txt
@@ -1,0 +1,5 @@
+# List of available configs for installer
+# baseFreq:filename:Description_no_spaces_allowed
+868:EU-global_conf.json:Europe_868MHz
+915:AU-global_conf.json:Australia_915MHz
+915:US-global_conf.json:United_States_915MHz


### PR DESCRIPTION
As discussed with Johan some time ago I've added a file with the list of available configurations to the repo. This file will be used by the installer script (for MultiTech gateways) to allow the user to choose from the available configurations while installing the (TTN) poly packet forwarder without requiring changes to the installer script when new configurations become available.
