### PR TITLE
Added global-conf for Indian frequency plan.

### DIFF
--- a/IN-global_conf.json
+++ b/IN-global_conf.json
@@ -1,0 +1,213 @@
+{
+	"SX1301_conf": {
+		"lorawan_public": true,
+		"clksrc": 1,
+		"clksrc_desc": "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.",
+		"antenna_gain": 0,
+		"antenna_gain_desc": "antenna gain, in dBi",
+		"radio_0": {
+			"enable": true,
+			"type": "SX1257",
+			"freq": 866000000,
+			"rssi_offset": -166.0,
+			"tx_enable": true,
+			"tx_freq_min": 865000000,
+			"tx_freq_max": 867000000
+		},
+		"radio_1": {
+			"enable": true,
+			"type": "SX1257",
+			"freq": 866000000,
+			"rssi_offset": -166.0,
+			"tx_enable": false
+		},
+		"chan_multiSF_0": {
+			"desc": "Lora MAC, 125kHz, all SF, 865.0625 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": -937500
+		},
+		"chan_multiSF_1": {
+			"desc": "Lora MAC, 125kHz, all SF, 865.4025 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": -597500
+		},
+		"chan_multiSF_2": {
+			"desc": "Lora MAC, 125kHz, all SF, 865.9850 MHz",
+			"enable": true,
+			"radio": 1,
+			"if": -15000
+		},
+		"chan_multiSF_3": {
+			"desc": "disabled",
+			"enable": false,
+			"radio": 0,
+			"if": 0
+		},
+		"chan_multiSF_4": {
+			"desc": "disabled",
+			"enable": false,
+			"radio": 0,
+			"if": 0
+		},
+		"chan_multiSF_5": {
+			"desc": "disabled",
+			"enable": false,
+			"radio": 0,
+			"if": 0
+		},
+		"chan_multiSF_6": {
+			"desc": "disabled",
+			"enable": false,
+			"radio": 0,
+			"if": 0
+		},
+		"chan_multiSF_7": {
+			"desc": "disabled",
+			"enable": false,
+			"radio": 0,
+			"if": 0
+		},
+		"chan_Lora_std": {
+			"desc": "Lora MAC, 250kHz, SF7",
+			"enable": false,
+			"radio": 1,
+			"if": 0,
+			"bandwidth": 250000,
+			"spread_factor": 7
+		},
+		"chan_FSK": {
+			"desc": "FSK 50kbps",
+			"enable": false,
+			"radio": 1,
+			"if": 0,
+			"bandwidth": 125000,
+			"datarate": 50000
+		},
+		"tx_lut_0": {
+			"desc": "TX gain table, index 0",
+			"pa_gain": 0,
+			"mix_gain": 8,
+			"rf_power": -6,
+			"dig_gain": 0
+		},
+		"tx_lut_1": {
+			"desc": "TX gain table, index 1",
+			"pa_gain": 0,
+			"mix_gain": 10,
+			"rf_power": -3,
+			"dig_gain": 0
+		},
+		"tx_lut_2": {
+			"desc": "TX gain table, index 2",
+			"pa_gain": 0,
+			"mix_gain": 12,
+			"rf_power": 0,
+			"dig_gain": 0
+		},
+		"tx_lut_3": {
+			"desc": "TX gain table, index 3",
+			"pa_gain": 1,
+			"mix_gain": 8,
+			"rf_power": 3,
+			"dig_gain": 0
+		},
+		"tx_lut_4": {
+			"desc": "TX gain table, index 4",
+			"pa_gain": 1,
+			"mix_gain": 10,
+			"rf_power": 6,
+			"dig_gain": 0
+		},
+		"tx_lut_5": {
+			"desc": "TX gain table, index 5",
+			"pa_gain": 1,
+			"mix_gain": 12,
+			"rf_power": 10,
+			"dig_gain": 0
+		},
+		"tx_lut_6": {
+			"desc": "TX gain table, index 6",
+			"pa_gain": 1,
+			"mix_gain": 13,
+			"rf_power": 11,
+			"dig_gain": 0
+		},
+		"tx_lut_7": {
+			"desc": "TX gain table, index 7",
+			"pa_gain": 2,
+			"mix_gain": 9,
+			"rf_power": 12,
+			"dig_gain": 0
+		},
+		"tx_lut_8": {
+			"desc": "TX gain table, index 8",
+			"pa_gain": 1,
+			"mix_gain": 15,
+			"rf_power": 13,
+			"dig_gain": 0
+		},
+		"tx_lut_9": {
+			"desc": "TX gain table, index 9",
+			"pa_gain": 2,
+			"mix_gain": 10,
+			"rf_power": 14,
+			"dig_gain": 0
+		},
+		"tx_lut_10": {
+			"desc": "TX gain table, index 10",
+			"pa_gain": 2,
+			"mix_gain": 11,
+			"rf_power": 16,
+			"dig_gain": 0
+		},
+		"tx_lut_11": {
+			"desc": "TX gain table, index 11",
+			"pa_gain": 3,
+			"mix_gain": 9,
+			"rf_power": 20,
+			"dig_gain": 0
+		},
+		"tx_lut_12": {
+			"desc": "TX gain table, index 12",
+			"pa_gain": 3,
+			"mix_gain": 10,
+			"rf_power": 23,
+			"dig_gain": 0
+		},
+		"tx_lut_13": {
+			"desc": "TX gain table, index 13",
+			"pa_gain": 3,
+			"mix_gain": 11,
+			"rf_power": 25,
+			"dig_gain": 0
+		},
+		"tx_lut_14": {
+			"desc": "TX gain table, index 14",
+			"pa_gain": 3,
+			"mix_gain": 12,
+			"rf_power": 26,
+			"dig_gain": 0
+		},
+		"tx_lut_15": {
+			"desc": "TX gain table, index 15",
+			"pa_gain": 3,
+			"mix_gain": 14,
+			"rf_power": 27,
+			"dig_gain": 0
+		}
+	},
+	"gateway_conf": {
+		"server_address": "router.as.thethings.network",
+		"serv_port_up": 1700,
+		"serv_port_down": 1700,
+		"servers": [ {
+			"server_address": "router.as.thethings.network",
+			"serv_port_up": 1700,
+			"serv_port_down": 1700,
+			"serv_enabled": true
+		} ]
+	}
+
+}

--- a/frequency-plans.yml
+++ b/frequency-plans.yml
@@ -36,3 +36,8 @@ AS_923_925:
 
 KR_920_923:
   base_freq: 915
+
+IN_865_867:
+  description: India 865-867MHz
+  base_freq: 868
+  global_conf: IN-global_conf.json


### PR DESCRIPTION
Preliminary frequency plan for India. Currently using only the three default LoRaWAN channels as from the regional parameters doc: 
https://www.thethingsnetwork.org/forum/t/frequency-plan-india/7069/5
https://github.com/TheThingsNetwork/wiki/blob/rewrite/LoRaWAN/Frequencies/Frequency-Plans.md#in865-867