### PR TITLE
Bandplan didn't work for uplink ch0/1. Corrected per Multi-Tech.

### DIFF
--- a/IN-global_conf.json
+++ b/IN-global_conf.json
@@ -9,7 +9,7 @@
 			"enable": true,
 			"type": "SX1257",
 			"freq": 865200000,
-			"rssi_offset": -162,
+			"rssi_offset": -166.0,
 			"tx_enable": true,
 			"tx_freq_min": 865000000,
 			"tx_freq_max": 867000000,
@@ -19,7 +19,7 @@
 			"enable": true,
 			"type": "SX1257",
 			"freq": 866385000,
-			"rssi_offset": -162,
+			"rssi_offset": -166.0,
 			"tx_enable": false
 		},
 		"chan_multiSF_0": {

--- a/IN-global_conf.json
+++ b/IN-global_conf.json
@@ -3,8 +3,8 @@
 		"lorawan_public": true,
 		"clksrc": 1,
 		"clksrc_desc": "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.",
-		"antenna_gain": 1.4,
-		"antenna_gain_desc": "antenna gain, in dBi",
+		"antenna_gain": 0,
+		"antenna_gain_desc": "antenna gain, in dBi. MultiTech has this as 1.4 by default.",
 		"radio_0": {
 			"enable": true,
 			"type": "SX1257",

--- a/IN-global_conf.json
+++ b/IN-global_conf.json
@@ -1,78 +1,79 @@
 {
 	"SX1301_conf": {
 		"lorawan_public": true,
-		"clksrc": 1,
+		"clksrc": 0,
 		"clksrc_desc": "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.",
-		"antenna_gain": 0,
+		"antenna_gain": 1.4,
 		"antenna_gain_desc": "antenna gain, in dBi",
 		"radio_0": {
 			"enable": true,
 			"type": "SX1257",
-			"freq": 866000000,
-			"rssi_offset": -166.0,
+			"freq": 865200000,
+			"rssi_offset": -162,
 			"tx_enable": true,
 			"tx_freq_min": 865000000,
-			"tx_freq_max": 867000000
+			"tx_freq_max": 867000000,
+			"tx_notch_freq": 129000
 		},
 		"radio_1": {
 			"enable": true,
 			"type": "SX1257",
-			"freq": 866000000,
-			"rssi_offset": -166.0,
+			"freq": 866385000,
+			"rssi_offset": -162,
 			"tx_enable": false
 		},
 		"chan_multiSF_0": {
 			"desc": "Lora MAC, 125kHz, all SF, 865.0625 MHz",
 			"enable": true,
-			"radio": 1,
-			"if": -937500
+			"radio": 0,
+			"if": -137500
 		},
 		"chan_multiSF_1": {
 			"desc": "Lora MAC, 125kHz, all SF, 865.4025 MHz",
 			"enable": true,
-			"radio": 1,
-			"if": -597500
+			"radio": 0,
+			"if": 202500
 		},
 		"chan_multiSF_2": {
 			"desc": "Lora MAC, 125kHz, all SF, 865.9850 MHz",
 			"enable": true,
 			"radio": 1,
-			"if": -15000
+			"if": -400000
 		},
 		"chan_multiSF_3": {
 			"desc": "disabled",
 			"enable": false,
 			"radio": 0,
-			"if": 0
+			"if": 32500
 		},
 		"chan_multiSF_4": {
 			"desc": "disabled",
 			"enable": false,
-			"radio": 0,
-			"if": 0
+			"radio": 1,
+			"if": -200000
 		},
 		"chan_multiSF_5": {
 			"desc": "disabled",
 			"enable": false,
-			"radio": 0,
+			"radio": 1,
 			"if": 0
 		},
 		"chan_multiSF_6": {
 			"desc": "disabled",
 			"enable": false,
-			"radio": 0,
-			"if": 0
+			"radio": 1,
+			"if": 200000
 		},
 		"chan_multiSF_7": {
 			"desc": "disabled",
 			"enable": false,
-			"radio": 0,
-			"if": 0
+			"radio": 1,
+			"if": 400000
 		},
 		"chan_Lora_std": {
 			"desc": "Lora MAC, 250kHz, SF7",
 			"enable": false,
-			"radio": 1,
+			"radio": 0,
 			"if": 0,
 			"bandwidth": 250000,
 			"spread_factor": 7
@@ -81,37 +82,38 @@
 			"desc": "FSK 50kbps",
 			"enable": false,
 			"radio": 1,
-			"if": 0,
+			"if": 300000,
 			"bandwidth": 125000,
-			"datarate": 50000
+			"datarate": 50000,
+			"freq_deviation": 25000
 		},
 		"tx_lut_0": {
 			"desc": "TX gain table, index 0",
 			"pa_gain": 0,
-			"mix_gain": 8,
+			"mix_gain": 9,
 			"rf_power": -6,
-			"dig_gain": 0
+			"dig_gain": 1
 		},
 		"tx_lut_1": {
 			"desc": "TX gain table, index 1",
 			"pa_gain": 0,
-			"mix_gain": 10,
+			"mix_gain": 12,
 			"rf_power": -3,
-			"dig_gain": 0
+			"dig_gain": 1
 		},
 		"tx_lut_2": {
 			"desc": "TX gain table, index 2",
-			"pa_gain": 0,
-			"mix_gain": 12,
+			"pa_gain": 1,
+			"mix_gain": 8,
 			"rf_power": 0,
-			"dig_gain": 0
+			"dig_gain": 2
 		},
 		"tx_lut_3": {
 			"desc": "TX gain table, index 3",
 			"pa_gain": 1,
-			"mix_gain": 8,
+			"mix_gain": 11,
 			"rf_power": 3,
-			"dig_gain": 0
+			"dig_gain": 3
 		},
 		"tx_lut_4": {
 			"desc": "TX gain table, index 4",
@@ -122,17 +124,17 @@
 		},
 		"tx_lut_5": {
 			"desc": "TX gain table, index 5",
-			"pa_gain": 1,
-			"mix_gain": 12,
+			"pa_gain": 2,
+			"mix_gain": 11,
 			"rf_power": 10,
-			"dig_gain": 0
+			"dig_gain": 3
 		},
 		"tx_lut_6": {
 			"desc": "TX gain table, index 6",
-			"pa_gain": 1,
-			"mix_gain": 13,
+			"pa_gain": 2,
+			"mix_gain": 9,
 			"rf_power": 11,
-			"dig_gain": 0
+			"dig_gain": 1
 		},
 		"tx_lut_7": {
 			"desc": "TX gain table, index 7",
@@ -143,57 +145,57 @@
 		},
 		"tx_lut_8": {
 			"desc": "TX gain table, index 8",
-			"pa_gain": 1,
-			"mix_gain": 15,
+			"pa_gain": 2,
+			"mix_gain": 11,
 			"rf_power": 13,
-			"dig_gain": 0
+			"dig_gain": 2
 		},
 		"tx_lut_9": {
 			"desc": "TX gain table, index 9",
 			"pa_gain": 2,
-			"mix_gain": 10,
+			"mix_gain": 11,
 			"rf_power": 14,
-			"dig_gain": 0
+			"dig_gain": 1
 		},
 		"tx_lut_10": {
 			"desc": "TX gain table, index 10",
 			"pa_gain": 2,
-			"mix_gain": 11,
+			"mix_gain": 12,
 			"rf_power": 16,
 			"dig_gain": 0
 		},
 		"tx_lut_11": {
 			"desc": "TX gain table, index 11",
 			"pa_gain": 3,
-			"mix_gain": 9,
+			"mix_gain": 10,
 			"rf_power": 20,
-			"dig_gain": 0
+			"dig_gain": 3
 		},
 		"tx_lut_12": {
 			"desc": "TX gain table, index 12",
 			"pa_gain": 3,
-			"mix_gain": 10,
+			"mix_gain": 9,
 			"rf_power": 23,
 			"dig_gain": 0
 		},
 		"tx_lut_13": {
 			"desc": "TX gain table, index 13",
 			"pa_gain": 3,
-			"mix_gain": 11,
+			"mix_gain": 12,
 			"rf_power": 25,
-			"dig_gain": 0
+			"dig_gain": 2
 		},
 		"tx_lut_14": {
 			"desc": "TX gain table, index 14",
 			"pa_gain": 3,
-			"mix_gain": 12,
+			"mix_gain": 13,
 			"rf_power": 26,
 			"dig_gain": 0
 		},
 		"tx_lut_15": {
 			"desc": "TX gain table, index 15",
 			"pa_gain": 3,
-			"mix_gain": 14,
+			"mix_gain": 15,
 			"rf_power": 27,
 			"dig_gain": 0
 		}

--- a/IN-global_conf.json
+++ b/IN-global_conf.json
@@ -1,7 +1,7 @@
 {
 	"SX1301_conf": {
 		"lorawan_public": true,
-		"clksrc": 0,
+		"clksrc": 1,
 		"clksrc_desc": "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.",
 		"antenna_gain": 1.4,
 		"antenna_gain_desc": "antenna gain, in dBi",

--- a/IN-global_conf.json
+++ b/IN-global_conf.json
@@ -4,7 +4,7 @@
 		"clksrc": 1,
 		"clksrc_desc": "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.",
 		"antenna_gain": 0,
-		"antenna_gain_desc": "antenna gain, in dBi. MultiTech has this as 1.4 by default.",
+		"antenna_gain_desc": "antenna gain, in dBi",
 		"radio_0": {
 			"enable": true,
 			"type": "SX1257",
@@ -90,30 +90,30 @@
 		"tx_lut_0": {
 			"desc": "TX gain table, index 0",
 			"pa_gain": 0,
-			"mix_gain": 9,
+			"mix_gain": 8,
 			"rf_power": -6,
-			"dig_gain": 1
+			"dig_gain": 0
 		},
 		"tx_lut_1": {
 			"desc": "TX gain table, index 1",
 			"pa_gain": 0,
-			"mix_gain": 12,
+			"mix_gain": 10,
 			"rf_power": -3,
-			"dig_gain": 1
+			"dig_gain": 0
 		},
 		"tx_lut_2": {
 			"desc": "TX gain table, index 2",
-			"pa_gain": 1,
-			"mix_gain": 8,
+			"pa_gain": 0,
+			"mix_gain": 12,
 			"rf_power": 0,
-			"dig_gain": 2
+			"dig_gain": 0
 		},
 		"tx_lut_3": {
 			"desc": "TX gain table, index 3",
 			"pa_gain": 1,
-			"mix_gain": 11,
+			"mix_gain": 8,
 			"rf_power": 3,
-			"dig_gain": 3
+			"dig_gain": 0
 		},
 		"tx_lut_4": {
 			"desc": "TX gain table, index 4",
@@ -124,17 +124,17 @@
 		},
 		"tx_lut_5": {
 			"desc": "TX gain table, index 5",
-			"pa_gain": 2,
-			"mix_gain": 11,
+			"pa_gain": 1,
+			"mix_gain": 12,
 			"rf_power": 10,
-			"dig_gain": 3
+			"dig_gain": 0
 		},
 		"tx_lut_6": {
 			"desc": "TX gain table, index 6",
-			"pa_gain": 2,
-			"mix_gain": 9,
+			"pa_gain": 1,
+			"mix_gain": 13,
 			"rf_power": 11,
-			"dig_gain": 1
+			"dig_gain": 0
 		},
 		"tx_lut_7": {
 			"desc": "TX gain table, index 7",
@@ -145,57 +145,57 @@
 		},
 		"tx_lut_8": {
 			"desc": "TX gain table, index 8",
-			"pa_gain": 2,
-			"mix_gain": 11,
+			"pa_gain": 1,
+			"mix_gain": 15,
 			"rf_power": 13,
-			"dig_gain": 2
+			"dig_gain": 0
 		},
 		"tx_lut_9": {
 			"desc": "TX gain table, index 9",
 			"pa_gain": 2,
-			"mix_gain": 11,
+			"mix_gain": 10,
 			"rf_power": 14,
-			"dig_gain": 1
+			"dig_gain": 0
 		},
 		"tx_lut_10": {
 			"desc": "TX gain table, index 10",
 			"pa_gain": 2,
-			"mix_gain": 12,
+			"mix_gain": 11,
 			"rf_power": 16,
 			"dig_gain": 0
 		},
 		"tx_lut_11": {
 			"desc": "TX gain table, index 11",
 			"pa_gain": 3,
-			"mix_gain": 10,
+			"mix_gain": 9,
 			"rf_power": 20,
-			"dig_gain": 3
+			"dig_gain": 0
 		},
 		"tx_lut_12": {
 			"desc": "TX gain table, index 12",
 			"pa_gain": 3,
-			"mix_gain": 9,
+			"mix_gain": 10,
 			"rf_power": 23,
 			"dig_gain": 0
 		},
 		"tx_lut_13": {
 			"desc": "TX gain table, index 13",
 			"pa_gain": 3,
-			"mix_gain": 12,
+			"mix_gain": 11,
 			"rf_power": 25,
-			"dig_gain": 2
+			"dig_gain": 0
 		},
 		"tx_lut_14": {
 			"desc": "TX gain table, index 14",
 			"pa_gain": 3,
-			"mix_gain": 13,
+			"mix_gain": 12,
 			"rf_power": 26,
 			"dig_gain": 0
 		},
 		"tx_lut_15": {
 			"desc": "TX gain table, index 15",
 			"pa_gain": 3,
-			"mix_gain": 15,
+			"mix_gain": 14,
 			"rf_power": 27,
 			"dig_gain": 0
 		}


### PR DESCRIPTION
This is the fix for #18. We tested and confirmed function of all uplink and downlink channels 0/1/2 (as defined by the LoRaWAN regional specification).

We simply applied Multi-Tech's suggested changes.  Unfortunately, their changes also included subtle differences in the transmit look-up tables, the antenna gain, and so forth. I think this is all related to EIRP rules for India. I have asked for clarification on this, have not received it yet.

Nevertheless: IN866 works properly with this collection of settings and does not work properly with the old collection of settings. So my suggestion is that this be applied and then update later after researching the other changes.