### PR TITLE
Update AU-global_conf.json

### DIFF
--- a/AU-global_conf.json
+++ b/AU-global_conf.json
@@ -8,7 +8,7 @@
 		"radio_0": {
 			"enable": true,
 			"type": "SX1257",
-			"freq": 917100000,
+			"freq": 917200000,
 			"rssi_offset": -166.0,
 			"tx_enable": true,
 			"tx_freq_min": 915000000,
@@ -25,25 +25,25 @@
 			"desc": "Lora MAC, 125kHz, all SF, 916.8 MHz",
 			"enable": true,
 			"radio": 0,
-			"if": -300000
+			"if": -400000
 		},
 		"chan_multiSF_1": {
 			"desc": "Lora MAC, 125kHz, all SF, 917.0 MHz",
 			"enable": true,
 			"radio": 0,
-			"if": -100000
+			"if": -200000
 		},
 		"chan_multiSF_2": {
 			"desc": "Lora MAC, 125kHz, all SF, 917.2 MHz",
 			"enable": true,
 			"radio": 0,
-			"if": 100000
+			"if": 0
 		},
 		"chan_multiSF_3": {
 			"desc": "Lora MAC, 125kHz, all SF, 917.4 MHz",
 			"enable": true,
 			"radio": 0,
-			"if": 300000
+			"if": 200000
 		},
 		"chan_multiSF_4": {
 			"desc": "Lora MAC, 125kHz, all SF, 917.6 MHz",
@@ -73,7 +73,7 @@
 			"desc": "Lora MAC, 500kHz, SF8, 917.5 MHz",
 			"enable": true,
 			"radio": 0,
-			"if": 400000,
+			"if": 300000,
 			"bandwidth": 500000,
 			"spread_factor": 8
 		},


### PR DESCRIPTION
Shift the frequency of radio 0 up by 100kHz and update the channels' intermediate frequencies. This is according to a Semtech recommendation to prevent the 500kHz std channel from falling outside of the range of the sx1257.

Fixes #22 